### PR TITLE
Ensure all tags are fetched

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
       - name: Setup variables
         id: tags
         run: echo "tags=$(git tag -l | jq -R . | jq -cs .)" >> $GITHUB_ENV
@@ -32,6 +33,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Get tags
         run: |


### PR DESCRIPTION
Hello,

This time should be the last :-)

What's weird is that it built sucessfully in https://github.com/Silex/quasaScale-backend/actions/runs/12478681573/job/34826608887 when it should not have, I guess when you push a tag what is cloned by default is different than what happens when cron runs.

Also, don't be afraid of many such ping-pongs, setting up github actions always takes a lot of trial & errors.